### PR TITLE
Fix solver exception documentation typo

### DIFF
--- a/src/main/java/eu/sergehelfrich/ersa/solver/FunctionCallable.java
+++ b/src/main/java/eu/sergehelfrich/ersa/solver/FunctionCallable.java
@@ -26,7 +26,7 @@ public interface FunctionCallable {
      * 
      * @param x x
      * @return y y
-     * @throws eu.sergehelfrich.ersa.solver.SolverException Solver doe not converge
+     * @throws eu.sergehelfrich.ersa.solver.SolverException Solver does not converge.
      */
     public double function(double x) throws SolverException;
        


### PR DESCRIPTION
## Summary
- correct the solver exception Javadoc message in `FunctionCallable`

------
https://chatgpt.com/codex/tasks/task_e_68f9fac8d094832787a73742a151f0f7