### PR TITLE
Fix DewTest Javadoc reference

### DIFF
--- a/src/test/java/eu/sergehelfrich/ersa/DewTest.java
+++ b/src/test/java/eu/sergehelfrich/ersa/DewTest.java
@@ -63,7 +63,7 @@ public class DewTest {
     }
 
     /**
-     * Test of expectedDewPoint method, of class Dew.
+     * Test of the {@link Dew#dewPoint(double, double)} method.
      */
     @Test
     public void testDewPoint() throws Exception {


### PR DESCRIPTION
## Summary
- update the DewTest testDewPoint Javadoc to reference the dewPoint method directly

------
https://chatgpt.com/codex/tasks/task_e_68f9ffbfde808327a1f5ec3dbb1d3d4f