### PR TITLE
Fix JitPack build by using JavaFX 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = '11'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 javafx {
-    version = "20"
+    version = "11.0.2"
     modules = [ 'javafx.controls' ]
 }
 


### PR DESCRIPTION
## Summary
- align the JavaFX plugin configuration with the Java 11 runtime used on JitPack to avoid class version mismatches during compilation

## Testing
- ./gradlew clean build -x test *(fails in the container because Gradle caches contain class files compiled with Java 21, which are incompatible with the Java 11 runtime used for the script cache)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc56eeb3883278e85c43a2829315c